### PR TITLE
Change private to private_trap in drosera.toml

### DIFF
--- a/drosera.toml
+++ b/drosera.toml
@@ -13,5 +13,5 @@ cooldown_period_blocks = 33
 min_number_of_operators = 1
 max_number_of_operators = 2
 block_sample_size = 10
-private = true
+private_trap = true
 whitelist = []


### PR DESCRIPTION
Fixing a mistake in `drosera.toml`.
According to the [official documentation](https://dev.drosera.io/docs/trappers/drosera-cli), the parameter should be named `private_trap`, but not `private`.